### PR TITLE
changed bow's arrow

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -133,7 +133,7 @@ rcbows.register_bow("farbows:bow_wood", {
 	base_texture = "farbows_base_bow_wood.png",
 	overlay_empty = "farbows_overlay_empty.png",
 	overlay_charged = "farbows_overlay_charged.png",
-	arrows = "farbows:e_arrow",
+	arrows = {"farbows:explosive_arrow", "farbows:fire_arrow", "farbows:water_arrow", "farbows:e_arrow"},
 	sounds = {
 		max_hear_distance = 10,
 		gain = 0.4,
@@ -154,7 +154,7 @@ rcbows.register_bow("farbows:bow_mese", {
 	base_texture = "farbows_base_bow_mese.png",
 	overlay_empty = "farbows_overlay_empty.png",
 	overlay_charged = "farbows_overlay_charged.png",
-	arrows = "farbows:e_arrow",
+	arrows = {"farbows:explosive_arrow", "farbows:fire_arrow", "farbows:water_arrow", "farbows:e_arrow"},
 	sounds = {
 		max_hear_distance = 10,
 		gain = 0.4,


### PR DESCRIPTION
The mese bow and the wooden bow have the same shape as the flaming bow, but the first two cannot shoot special arrows. This may be unreasonable. All three bows support better, allowing players to shoot even when there is no black stone. Special arrows (pure survival mode).